### PR TITLE
Use device's audio_effects.conf only, if defined.

### DIFF
--- a/target/product/generic_no_telephony.mk
+++ b/target/product/generic_no_telephony.mk
@@ -45,8 +45,10 @@ PRODUCT_PACKAGES += \
     vibrator.default \
     power.default
 
+ifneq ($(TARGET_USE_DEVICE_AUDIO_EFFECTS_CONF),true)
 PRODUCT_COPY_FILES := \
         frameworks/av/media/libeffects/data/audio_effects.conf:system/etc/audio_effects.conf
+endif
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.carrier=unknown


### PR DESCRIPTION
Compiler unexpectedly ignores device's audio_effects.conf to copy one from framework/av/media/libeffects/data