### PR TITLE
Revert "core: use 0 compression when creating the target_files package"

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -2125,8 +2125,8 @@ endif
 	@# Zip everything up, preserving symlinks and placing META/ files first to
 	@# help early validation of the .zip file while uploading it.
 	$(hide) (cd $(zip_root) && \
-	        zip -0qryX ../$(notdir $@) ./META && \
-	        zip -0qryXu ../$(notdir $@) .)
+	        zip -qryX ../$(notdir $@) ./META && \
+	        zip -qryXu ../$(notdir $@) .)
 	@# Run fs_config on all the system, vendor, boot ramdisk,
 	@# and recovery ramdisk files in the zip, and save the output
 	$(hide) zipinfo -1 $@ | awk 'BEGIN { FS="SYSTEM/" } /^SYSTEM\// {print "system/" $$2}' | $(HOST_OUT_EXECUTABLES)/fs_config -C -D $(TARGET_OUT) -S $(SELINUX_FC) > $(zip_root)/META/filesystem_config.txt


### PR DESCRIPTION
on zerofltexx, without it, the zip is very big and heavy. with this tweak we can fix and decrease zip size
This reverts commit cfadb8b34f224b27451432f77fef2e7d32f06372.