### PR TITLE
Bump Security String to 2019-06-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -181,7 +181,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2019-05-05
+      PLATFORM_SECURITY_PATCH := 2019-06-05
 endif
 
 ifndef PLATFORM_BASE_OS


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2018-9526   A-112159033  ID     High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2090   A-128599183  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2091   A-128599660  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1
CVE-2019-2092   A-128599668  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2094   A-129068792  RCE    Critical   7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2096   A-123237974  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2097   A-117606285  RCE    Critical   7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2098   A-128599467  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2099   A-123583388  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2102   A-128843052  EoP    High       7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9

Not Implemented:
================
None

Not Applicable (platform source):
===============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2019-2093   A-119292397  RCE    Critical   9
CVE-2019-2095   A-124232283  RCE    Critical   9

Change-Id: I6d2feddfde0bb0570d40894c1b4d12db15628f3c