### PR TITLE
Bump Security String to 2019-07-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -131,7 +131,7 @@ ifeq "" "$(PLATFORM_SECURITY_PATCH)"
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-    PLATFORM_SECURITY_PATCH := 2019-06-05
+    PLATFORM_SECURITY_PATCH := 2019-07-05
 endif
 
 ifeq "" "$(PLATFORM_BASE_OS)"


### PR DESCRIPTION
Implemented:
============
CVE:            References:     Type:   Severity:       Updated AOSP versions:
CVE-2019-2105   A-116114182     RCE     High            7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2106   A-130023983     RCE     Critical        7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2107   A-130024844     RCE     Critical        7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2109   A-130651570     RCE     Critical        7.0, 7.1.1, 7.1.2, 8.0, 8.1
CVE-2019-2116   A-117105007     ID      High            7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9
CVE-2019-2117   A-124107808     ID      High            7.0, 7.1.1, 7.1.2, 8.0, 8.1, 9

Not Implemented:
================
CVE:            References:     Type:   Severity:       Updated AOSP versions:
None

Not Applicable (platform source):
=================================
CVE:            References:     Type:   Severity:       Updated AOSP versions:
CVE-2019-2104   A-131356202     ID      High            8.0, 8.1, 9
CVE-2019-2111   A-122856181     RCE     Critical        9
CVE-2019-2112   A-117997080     EoP     High            8.0, 8.1, 9
CVE-2019-2118   A-130161842     ID      High            8.0, 8.1, 9
CVE-2019-2119   A-131622568     ID      High            8.0, 8.1, 9

Change-Id: I17483a0ed070e82f4025423f137de6f31617a588